### PR TITLE
docs: publish MkDocs site to GitHub Pages on merged PRs

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,0 +1,54 @@
+name: Publish Documentation
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build site
+        run: mkdocs build --site-dir site
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+# LEAF Documentation
+
+## Overview
+Welcome to the LEAF documentation site.
+
+## When to use
+Use this site to understand LEAF concepts, architecture, workflows, and operational guidance.
+
+## Example
+Start with these sections:
+- [Introduction: What Is LEAF](introduction/what-is-leaf.md)
+- [Getting Started: Quickstart](getting-started/quickstart.md)
+- [Architecture: Overview](architecture/overview.md)
+
+## Related topics
+See also:
+- [Core Concepts: Nodes](core-concepts/nodes.md)
+- [Workflows: Execution Lifecycle](workflows/execution-lifecycle.md)
+- [Reference: Glossary](reference/glossary.md)

--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -1,0 +1,8 @@
+window.mermaidConfig = {
+  startOnLoad: true,
+  securityLevel: 'loose',
+};
+
+if (window.mermaid) {
+  window.mermaid.initialize(window.mermaidConfig);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,28 @@
+site_name: LEAF Documentation
+site_description: Documentation for the LEAF graph-based dataflow language
+site_url: https://leafgon.github.io/leaf-docs/
+repo_url: https://github.com/leafgon/leaf-docs
+repo_name: leafgon/leaf-docs
+
+docs_dir: docs
+
+theme:
+  name: material
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+extra_javascript:
+  - https://unpkg.com/mermaid@10/dist/mermaid.min.js
+  - javascripts/mermaid-init.js

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.6,<2.0
+mkdocs-material>=9.5,<10.0
+pymdown-extensions>=10.0,<11.0


### PR DESCRIPTION
## Linked issue
- Closes #2

## Scope summary
- Add MkDocs site configuration in mkdocs.yml
- Add docs homepage entry in docs/index.md
- Add Mermaid initialization asset for rendered diagrams in docs/javascripts/mermaid-init.js
- Add docs dependency manifest in requirements-docs.txt
- Add GitHub Actions workflow in .github/workflows/publish-pages.yml that deploys to GitHub Pages when PRs are merged into main

## Risk assessment
Low

## Backward compatibility impact
No application runtime/API changes. Documentation hosting automation only.

## Local checks run
- python3 -m venv .venv-docs && source .venv-docs/bin/activate && pip install -q -r requirements-docs.txt && mkdocs build --site-dir site