### PR TITLE
ci: fix Pages deploy trigger to run from main branch context

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,8 +1,7 @@
 name: Publish Documentation
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
   workflow_dispatch:
 
@@ -17,7 +16,6 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Linked issue
- Closes #4

## Scope summary
- Change Publish Documentation workflow trigger from pull_request closed on main to push on main
- Remove merged PR conditional gate because trigger is now main pushes and manual dispatch
- Keep all build and deploy steps unchanged

## Root cause
GitHub Pages deployment environment rejected runs coming from refs/pull/<id>/merge due to environment protection rules.

## Risk assessment
Low

## Backward compatibility impact
No application runtime or API changes. CI trigger fix only.

## Local checks run
- Verified workflow YAML syntax and structure after trigger change
