### PR TITLE
docs: remove provenance phrasing and use canonical voice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Use this guide when proposing changes to LEAF documentation in this repository.
 ## Example
 Recommended workflow:
 1. Pick one page or one tightly scoped topic.
-2. Update content using the agreed LEAF source material (or clearly label assumptions).
+2. Update content using agreed LEAF documentation conventions (or clearly label assumptions).
 3. Add or update cross-links.
 4. Keep Mermaid diagrams simple and renderable.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 This repository contains documentation for **LEAF**, a graph-based dataflow programming language with a complementary text domain powered by **LEAFlisp**.
 
-This documentation is sourced from LEAF source material and organized into a structured documentation layout.
+This documentation is organized into a structured layout for LEAF.
 
 ## When to use
 Use this repository when you need:

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,7 +1,7 @@
 # Overview
 
 ## Overview
-API interaction in LEAF is represented as graph wiring around integration nodes and LEAFlisp transforms. The source corpus references HTTP and provider-oriented element patterns.
+API interaction in LEAF is represented as graph wiring around integration nodes and LEAFlisp transforms, including HTTP and provider-oriented element patterns.
 
 ## When to use
 Use this page when documenting service boundaries and request/response flow in LEAF.

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1,7 +1,7 @@
 # Schemas
 
 ## Overview
-Schema handling in this corpus is JSON-centric via LEAFlisp dictionaries/lists and key-based access (`get`, `keys`, `values`).
+Schema handling is JSON-centric via LEAFlisp dictionaries/lists and key-based access (`get`, `keys`, `values`).
 
 ## When to use
 Use this page when defining or validating payload structure in workflows.

--- a/docs/architecture/execution-model.md
+++ b/docs/architecture/execution-model.md
@@ -1,7 +1,7 @@
 # Execution Model
 
 ## Overview
-Execution in LEAF is data-driven. Nodes fire when their required inputs are available. The corpus describes default synchronous behavior for multi-input nodes, plus explicit mechanisms to alter that behavior:
+Execution in LEAF is data-driven. Nodes fire when their required inputs are available. Multi-input nodes are synchronous by default, with explicit mechanisms to alter that behavior:
 - `chronos`: allows asynchronous handling of multiple incoming lines.
 - `anchor`: inactivates a graph/subgraph (similar to commenting-out behavior).
 

--- a/docs/architecture/scaling-and-performance.md
+++ b/docs/architecture/scaling-and-performance.md
@@ -1,7 +1,7 @@
 # Scaling And Performance
 
 ## Overview
-The corpus emphasizes readability and maintainability as performance enablers for human teams. Practical scaling guidance for LEAF workflows includes:
+Readability and maintainability are performance enablers for human teams. Practical scaling guidance for LEAF workflows includes:
 - Keep graphs modular with spell/spelldef abstractions.
 - Use anchor edges to isolate inactive branches during development and staged rollouts.
 - Use chronos only where asynchronous behavior is necessary.

--- a/docs/architecture/state-management.md
+++ b/docs/architecture/state-management.md
@@ -1,7 +1,7 @@
 # State Management
 
 ## Overview
-The corpus frames LEAF execution as functionally pure by default: graph execution should not mutate hidden global state. When transient state is required, `memoryio` provides runtime-local read/write storage.
+LEAF execution is functionally pure by default: graph execution should not mutate hidden global state. When transient state is required, `memoryio` provides runtime-local read/write storage.
 
 Memory stored in `memoryio` is temporary and can be lost on runtime refresh.
 

--- a/docs/architecture/system-components.md
+++ b/docs/architecture/system-components.md
@@ -1,7 +1,7 @@
 # System Components
 
 ## Overview
-From the source corpus, LEAF systems are composed of:
+LEAF systems are composed of:
 - Node categories: element, abstraction, utility, wizardry, I/O.
 - Edge types: dataflow, lambda, anchor.
 - Runtime semantics: synchronous default input joining with optional asynchronous coordination.

--- a/docs/backend/data-models.md
+++ b/docs/backend/data-models.md
@@ -1,7 +1,7 @@
 # Data Models
 
 ## Overview
-The corpus highlights JSON-native modeling in LEAFlisp. Dictionaries and lists are first-class values for passing structured data across nodes.
+LEAFlisp uses JSON-native modeling. Dictionaries and lists are first-class values for passing structured data across nodes.
 
 ## When to use
 Use this page when defining payload shapes shared across workflow boundaries.

--- a/docs/backend/overview.md
+++ b/docs/backend/overview.md
@@ -1,8 +1,8 @@
 # Overview
 
 ## Overview
-Backend-facing behavior in LEAF is represented through graph nodes and external integrations rather than hidden service code in this corpus snapshot. The most explicit backend-adjacent primitives are:
-- API/integration element nodes (for example HTTP, OpenAI, Directus in the corpus narrative).
+Backend-facing behavior in LEAF is represented through graph nodes and external integrations rather than hidden service code. The most explicit backend-adjacent primitives are:
+- API/integration element nodes (for example HTTP, OpenAI, and Directus).
 - Runtime-local storage with `memoryio`.
 - Configuration with `config` for URI-level authorization settings.
 

--- a/docs/backend/persistence.md
+++ b/docs/backend/persistence.md
@@ -1,7 +1,7 @@
 # Persistence
 
 ## Overview
-The source corpus explicitly describes `memoryio` as temporary runtime storage that is reset on execution refresh. Persistent storage strategy is therefore external to this corpus and should be integrated through dedicated service nodes.
+`memoryio` is temporary runtime storage that is reset on execution refresh. Persistent storage strategy is therefore external to LEAF graphs and should be integrated through dedicated service nodes.
 
 ## When to use
 Use this page when deciding between temporary state and durable storage.

--- a/docs/core-concepts/graph-model.md
+++ b/docs/core-concepts/graph-model.md
@@ -1,7 +1,7 @@
 # Graph Model
 
 ## Overview
-LEAF programs are modeled as directed graphs of nodes and typed edges. The corpus frames LEAF as directed acyclic graph-oriented for dataflow composition, extended by lambda and anchor relations.
+LEAF programs are modeled as directed graphs of nodes and typed edges. LEAF is directed acyclic graph-oriented for dataflow composition, extended by lambda and anchor relations.
 
 ```mermaid
 flowchart LR

--- a/docs/core-concepts/node-types/club.md
+++ b/docs/core-concepts/node-types/club.md
@@ -1,7 +1,7 @@
 # Club Suit Node
 
 ## Overview
-`club` is a canonical suit node type. The source corpus identifies it as one of the core element nodes in LEAF.
+`club` is a canonical suit node type and one of the core element nodes in LEAF.
 
 ## Usage pattern
 - Use `club` as a dedicated element endpoint within UI/dataflow pipelines.

--- a/docs/core-concepts/node-types/diamond.md
+++ b/docs/core-concepts/node-types/diamond.md
@@ -1,7 +1,7 @@
 # Diamond Suit Node
 
 ## Overview
-`diamond` is a canonical suit node type. The source corpus lists it as a first-class node type under element nodes.
+`diamond` is a canonical suit node type and a first-class node type under element nodes.
 
 ## Usage pattern
 - Use `diamond` when you want a distinct element node identity in your graph.

--- a/docs/core-concepts/node-types/element.md
+++ b/docs/core-concepts/node-types/element.md
@@ -35,7 +35,7 @@ flowchart LR
 - `sound`: defines sound using periodic waveforms; can process MIDI/sound inputs and emit sound output.
 - `prompt` (deprecated): prompt/form element; replaced by JSON-form patterns using the `html` element.
 - `popup`: wraps visualization content in a popup window.
-- `openai`: provides API-level access to OpenAI generative models (text and image usage noted in corpus).
+- `openai`: provides API-level access to OpenAI generative models for text and image workflows.
 - `midi`: provides MIDI interface input data from connected instruments.
 - `mediaplayer`: creates interactive audio/video playback visualization (for example, YouTube-sourced content).
 - `mediainput`: creates interactive visualization for image data input.

--- a/docs/core-concepts/node-types/heart.md
+++ b/docs/core-concepts/node-types/heart.md
@@ -1,7 +1,7 @@
 # Heart Suit Node
 
 ## Overview
-`heart` is a canonical suit node type. The source corpus lists it as one of the five primary element node types.
+`heart` is a canonical suit node type and one of the five primary element node types.
 
 ## Usage pattern
 - Use `heart` as a dedicated suit node where you want clear visual/interaction separation.

--- a/docs/core-concepts/node-types/loopyspell.md
+++ b/docs/core-concepts/node-types/loopyspell.md
@@ -1,7 +1,7 @@
 # Loopyspell Node
 
 ## Overview
-`loopyspell` is an abstraction node for iterative and context-sensitive orchestration. The corpus highlights three usage modes: in-situ spell definition/casting, iteration, and awaiting semantics.
+`loopyspell` is an abstraction node for iterative and context-sensitive orchestration with three usage modes: in-situ spell definition/casting, iteration, and awaiting semantics.
 
 ## Usage pattern
 - Use `loopyspell` when repeated processing is needed without manual graph duplication.

--- a/docs/core-concepts/nodes.md
+++ b/docs/core-concepts/nodes.md
@@ -1,7 +1,7 @@
 # Nodes
 
 ## Overview
-Nodes are the primary executable units in LEAF. The corpus defines 25 node types across five categories:
+Nodes are the primary executable units in LEAF. LEAF defines 25 node types across five categories:
 - Element nodes: suit nodes (`spade`, `diamond`, `heart`, `club`) and the element module node (`element`).
 - Abstraction nodes: `anchor`, `loopyspell`, `spell`, `spelldef`, `lambda`, `leafgraph`.
 - Utility nodes: `unbottle`, `bottle`, `crate`, `delabel`, `label`, `mix`, `gate`, `chronos`, `config`.

--- a/docs/core-concepts/runtime.md
+++ b/docs/core-concepts/runtime.md
@@ -1,7 +1,7 @@
 # Runtime
 
 ## Overview
-The LEAF runtime evaluates graph nodes according to incoming data availability and graph connectivity. Key runtime characteristics from the corpus:
+The LEAF runtime evaluates graph nodes according to incoming data availability and graph connectivity. Key runtime characteristics include:
 - Stateless by default (functional-purity leaning).
 - Optional temporary state through `memoryio`.
 - Synchronous multi-input behavior unless `chronos` is introduced.

--- a/docs/deployment/local-development.md
+++ b/docs/deployment/local-development.md
@@ -1,7 +1,7 @@
 # Local Development
 
 ## Overview
-Local development in this corpus context means iterative graph editing, immediate execution, and visual verification through `screenio`/`outport`.
+Local development means iterative graph editing, immediate execution, and visual verification through `screenio`/`outport`.
 
 ## When to use
 Use this page when developing or debugging new workflows.

--- a/docs/deployment/scaling.md
+++ b/docs/deployment/scaling.md
@@ -1,7 +1,7 @@
 # Scaling
 
 ## Overview
-Scaling LEAF workflows starts with graph clarity: modular spells, explicit boundaries, and controlled asynchronous behavior. Runtime scaling mechanisms are implementation-specific and not fully defined in the corpus.
+Scaling LEAF workflows starts with graph clarity: modular spells, explicit boundaries, and controlled asynchronous behavior. Runtime scaling mechanisms are implementation-specific and not fully defined in this documentation.
 
 ## When to use
 Use this page when workflows or usage volume grows beyond initial assumptions.

--- a/docs/examples/advanced-workflow.md
+++ b/docs/examples/advanced-workflow.md
@@ -15,7 +15,7 @@ flowchart TD
   M --> O[Outport]
 ```
 
-Loopyspell usage modes from the corpus:
+Loopyspell usage modes:
 1. In-situ spell definition and casting.
 2. Iteration.
 3. Awaiting semantics.

--- a/docs/examples/real-world-use-case.md
+++ b/docs/examples/real-world-use-case.md
@@ -1,7 +1,7 @@
 # Real World Use Case
 
 ## Overview
-The source corpus positions LEAF for event-heavy domains such as IoT, AI-assisted workflows, and interactive systems where explicit data routing improves maintainability.
+LEAF works well for event-heavy domains such as IoT, AI-assisted workflows, and interactive systems where explicit data routing improves maintainability.
 
 ## When to use
 Use this example template when documenting production use cases.

--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -3,7 +3,7 @@
 ## Overview
 Frontend behavior in LEAF is graph-driven: element nodes emit interactive visualization data, and `screenio` renders the final view payload.
 
-The corpus references element families for text editing, media, form-like interaction, and visualization.
+LEAF includes element families for text editing, media, form-like interaction, and visualization.
 
 ## When to use
 Use this page when designing user-facing flows inside LEAF graphs.

--- a/docs/frontend/visual-elements.md
+++ b/docs/frontend/visual-elements.md
@@ -1,7 +1,7 @@
 # Visual Elements
 
 ## Overview
-The corpus describes multiple visual/interactive element nodes (for example text, media, form, and immersive navigation related elements). These nodes output visualization data for `screenio`.
+LEAF provides multiple visual/interactive element nodes (for example text, media, form, and immersive navigation related elements). These nodes output visualization data for `screenio`.
 
 Some elements are noted as deprecated in favor of newer patterns; treat those as migration candidates in future revisions.
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 ## Overview
-The corpus explicitly mentions the `config` node for changing default authorization settings for a LEAF URI. Configuration is therefore modeled as graph-level behavior, not only external files.
+The `config` node changes default authorization settings for a LEAF URI. Configuration is therefore modeled as graph-level behavior, not only external files.
 
 ## When to use
 Use this page when adjusting runtime behavior tied to project identity, access, or environment assumptions.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,7 +1,7 @@
 # Installation
 
 ## Overview
-The source corpus indicates LEAF is authored through the LEAFgon platform. Initial setup is account-based: create a membership account, then create a project URI from your nickname and app name.
+LEAF is authored through the LEAFgon platform. Initial setup is account-based: create a membership account, then create a project URI from your nickname and app name.
 
 ## When to use
 Use this page when onboarding a new developer or setting up a new LEAF project.

--- a/docs/getting-started/project-structure.md
+++ b/docs/getting-started/project-structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 ## Overview
-At authoring time, LEAF projects are organized around graph pages and named resources. The corpus highlights naming as a first step: your nickname and app name form a URI-like identity.
+At authoring time, LEAF projects are organized around graph pages and named resources. Naming is a first step: your nickname and app name form a URI-like identity.
 
 Typical structure in this docs repo:
 - Concept docs in `docs/core-concepts/`

--- a/docs/introduction/comparison.md
+++ b/docs/introduction/comparison.md
@@ -3,7 +3,7 @@
 ## Overview
 LEAF differs from traditional control-flow programming by making data movement explicit through graph wiring. Compared with text-only models, LEAF surfaces execution pathways directly in the editor.
 
-Compared with many flow-based tools, the corpus positions LEAF as stronger in language-level abstraction through lambda-plane composition and LEAFlisp-backed transformations.
+Compared with many flow-based tools, LEAF is stronger in language-level abstraction through lambda-plane composition and LEAFlisp-backed transformations.
 
 ## When to use
 Use this page when deciding whether LEAF is a fit for event-driven, IoT, AI-adjacent, or interactive systems.

--- a/docs/introduction/design-goals.md
+++ b/docs/introduction/design-goals.md
@@ -1,7 +1,7 @@
 # Design Goals
 
 ## Overview
-The source corpus emphasizes these goals for LEAF:
+LEAF emphasizes these goals:
 - Accessibility: enable non-professional developers to author useful software.
 - Lower cognitive load: represent flow explicitly as graphs instead of hidden control flow.
 - Practical expressiveness: support abstraction, iteration, and data handling in one model.

--- a/docs/introduction/key-features.md
+++ b/docs/introduction/key-features.md
@@ -1,7 +1,7 @@
 # Key Features
 
 ## Overview
-Key features captured in the source corpus:
+Key LEAF features:
 - 25 node types grouped into five categories: element, abstraction, utility, wizardry, and I/O.
 - Three edge types: dataflow, lambda, and anchor.
 - Multi-plane graph model: horizontal dataflow and vertical lambda context.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 ## Overview
-Configuration in this corpus includes graph-native controls such as the `config` node and integration-specific settings passed through workflow inputs.
+Configuration includes graph-native controls such as the `config` node and integration-specific settings passed through workflow inputs.
 
 ## When to use
 Use this page as a canonical index of runtime and integration configuration expectations.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,7 +1,7 @@
 # Glossary
 
 ## Overview
-Canonical LEAF terms from the source corpus.
+Canonical LEAF terms used across this documentation.
 
 ## When to use
 Use this page for quick terminology alignment during design and review.

--- a/docs/reference/leaflisp.md
+++ b/docs/reference/leaflisp.md
@@ -3,7 +3,7 @@
 ## Overview
 LEAFlisp is the text-domain language used in LEAF for data shaping, branching, iteration, and transformation. It is a Lisp dialect with native JSON-friendly dictionaries (`{}`), lists (`[]`), and expression evaluation with function calls (`()`).
 
-This reference consolidates all LEAFlisp functions and operators described in the source corpus, with usage patterns and examples.
+This reference consolidates LEAFlisp functions and operators with usage patterns and examples.
 
 ## When to use
 Use LEAFlisp when graph wiring alone is not enough, especially for:

--- a/docs/workflows/error-handling.md
+++ b/docs/workflows/error-handling.md
@@ -1,7 +1,7 @@
 # Error Handling
 
 ## Overview
-Most workflow errors in the corpus context come from:
+Most workflow errors come from:
 - Type mismatches in LEAFlisp expressions (for example string vs number).
 - Missing dictionary keys or list index misuse.
 - Invalid assumptions about synchronous/asynchronous arrival.


### PR DESCRIPTION
## Linked Issue
Closes #14

## Scope Summary
- Removed provenance-style wording such as "source material", "documentation set/context", and similar phrasing.
- Rewrote affected sentences as direct documentation assertions.
- Preserved technical meaning while making the documentation voice canonical.

## Risk Assessment
Low. Documentation-only wording changes.

## Backward Compatibility
No behavior or API impact.

## Validation
- `python3 -m mkdocs build --strict`
- `rg -n "source material|documentation set|documentation context|documentation snapshot|narrative|\\b[Cc]orpus\\b" README.md SUMMARY.md docs CONTRIBUTING.md`
